### PR TITLE
Add pinned dependency on numpy.

### DIFF
--- a/simple/requirements.txt
+++ b/simple/requirements.txt
@@ -1,1 +1,2 @@
 adhawk
+numpy==1.20.3


### PR DESCRIPTION
Noticed this dependency was missing when starting from a clean venv on Windows.